### PR TITLE
Use nginx-debug binary in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
-nginx: nginx
+dockergen: docker-gen -watch -notify "nginx-debug -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+nginx: nginx-debug


### PR DESCRIPTION
I created this branch so that I could get debug logging for the [GOV.UK publishing-e2e-tests][1]. However, I subsequently found the [nginx-proxy-debug repo][2] which allowed me to do the same thing without jumping through so many hoops. I'm opening this PR just as a note to myself - I plan to close it immediately.

[1]: https://github.com/alphagov/publishing-e2e-tests
[2]: https://github.com/dmp1ce/nginx-proxy-debug